### PR TITLE
Examples implicit container allocation

### DIFF
--- a/massivedatacruncher/README.md
+++ b/massivedatacruncher/README.md
@@ -359,6 +359,8 @@ hdfs://127.0.0.1:9000 /airline1989 /1987 /examplesmdc
 
 tasksubmitterstream.cmd ../modules/examples.jar com.github.mdc.stream.transformation.examples.StreamReduceIntersection hdfs://127.0.0.1:9000 /airline1989 /1987 /examplesmdc
 
+tasksubmitterstream.cmd ../modules/examples.jar com.github.mdc.stream.transformation.examples.StreamReduceCachedIgnite hdfs://127.0.0.1:9000 /airline1989 /examplesmdc
+
 Stream Reduce SQL
 -----------------
 

--- a/massivedatacruncher/common/src/main/java/com/github/mdc/common/HeartBeatServer.java
+++ b/massivedatacruncher/common/src/main/java/com/github/mdc/common/HeartBeatServer.java
@@ -68,7 +68,7 @@ public sealed class HeartBeatServer implements HeartBeatServerMBean,HeartBeatClo
 			throw new Exception(MDCConstants.HEARTBEAT_EXCEPTION_SERVER_PORT);
 		}
 		if(config[2] instanceof String na) {
-			networkaddress = na;
+			networkaddress = NetworkUtil.getNetworkAddress(na);
 		}else {
 			throw new Exception(MDCConstants.HEARTBEAT_EXCEPTION_SERVER_HOST);
 		}

--- a/massivedatacruncher/common/src/main/java/com/github/mdc/common/HeartBeatServerStream.java
+++ b/massivedatacruncher/common/src/main/java/com/github/mdc/common/HeartBeatServerStream.java
@@ -70,7 +70,7 @@ public sealed class HeartBeatServerStream implements HeartBeatServerMBean,HeartB
 			throw new HeartBeatException(MDCConstants.HEARTBEAT_EXCEPTION_SERVER_PORT);
 		}
 		if (config[2] instanceof String na) {
-			networkaddress = na;
+			networkaddress = NetworkUtil.getNetworkAddress(na);
 		} else {
 			throw new HeartBeatException(MDCConstants.HEARTBEAT_EXCEPTION_SERVER_HOST);
 		}

--- a/massivedatacruncher/common/src/main/java/com/github/mdc/common/Utils.java
+++ b/massivedatacruncher/common/src/main/java/com/github/mdc/common/Utils.java
@@ -899,8 +899,9 @@ public class Utils {
 	 * @param bindaddr
 	 * @return jgroups channel object
 	 */
-	public static JChannel getChannelWithPStack(String bindaddr) {
+	public static synchronized JChannel getChannelWithPStack(String bindaddr) {
 		try {
+			System.setProperty(MDCConstants.BINDADDRESS, bindaddr);
 			var channel = new JChannel(System.getProperty(MDCConstants.USERDIR) + MDCConstants.BACKWARD_SLASH
 					+ MDCProperties.get().getProperty(MDCConstants.JGROUPSCONF));
 			return channel;
@@ -910,11 +911,11 @@ public class Utils {
 		return null;
 	}
 
-	public static JChannel getChannelTSSHA(String bindaddress, Receiver receiver) throws Exception {
+	public static synchronized JChannel getChannelTSSHA(String bindaddress, Receiver receiver) throws Exception {		
 		JChannel channel = getChannelWithPStack(
-				NetworkUtil.getNetworkAddress(MDCProperties.get().getProperty(MDCConstants.TASKSCHEDULERSTREAM_HOST)));
+				bindaddress);
 		if(!Objects.isNull(channel)) {
-			channel.setName(bindaddress);
+			channel.setName(bindaddress);			
 			channel.setDiscardOwnMessages(true);
 			if (!Objects.isNull(receiver)) {
 				channel.setReceiver(receiver);

--- a/massivedatacruncher/common/src/test/java/com/github/mdc/common/UtilsTest.java
+++ b/massivedatacruncher/common/src/test/java/com/github/mdc/common/UtilsTest.java
@@ -74,6 +74,6 @@ public class UtilsTest {
 	}
 	@Test
 	public void testloadLog4JSystemPropertiesClassPathProperInput() throws Exception {
-		Utils.loadLog4JSystemPropertiesClassPath(MDCConstants.MDC_PROPERTIES);
+		Utils.loadLog4JSystemPropertiesClassPath(MDCConstants.MDC_TEST_PROPERTIES);
 	}
 }

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/IgniteCommon.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/IgniteCommon.java
@@ -148,7 +148,12 @@ public sealed class IgniteCommon extends AbstractPipeline permits IgnitePipeline
 		job.jm.jobstarttime = System.currentTimeMillis();
 		job.jm.jobid = job.id;
 		MDCJobMetrics.put(job.jm);
-		PipelineConfig pipelineconfig = ((IgnitePipeline)root).pipelineconfig;
+		PipelineConfig pipelineconfig = null;
+		if(root instanceof IgnitePipeline ip) {
+			pipelineconfig = ip.pipelineconfig;
+		}else if(root instanceof MapPairIgnite mpi) {
+			pipelineconfig = mpi.pipelineconfig;
+		}
 		job.jm.mode = pipelineconfig.getMode();
 		if(!this.mdsroots.isEmpty()) {
 			for(AbstractPipeline root:this.mdsroots) {

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/MapPair.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/MapPair.java
@@ -22,8 +22,10 @@ import com.github.mdc.stream.functions.FlatMapFunction;
 import com.github.mdc.stream.functions.FoldByKey;
 import com.github.mdc.stream.functions.GroupByKeyFunction;
 import com.github.mdc.stream.functions.IntersectionFunction;
+import com.github.mdc.stream.functions.Join;
 import com.github.mdc.stream.functions.JoinPredicate;
 import com.github.mdc.stream.functions.KeyByFunction;
+import com.github.mdc.stream.functions.LeftJoin;
 import com.github.mdc.stream.functions.LeftOuterJoinPredicate;
 import com.github.mdc.stream.functions.LongTupleFlatMapFunction;
 import com.github.mdc.stream.functions.MapFunction;
@@ -32,6 +34,7 @@ import com.github.mdc.stream.functions.MapValuesFunction;
 import com.github.mdc.stream.functions.PeekConsumer;
 import com.github.mdc.stream.functions.PredicateSerializable;
 import com.github.mdc.stream.functions.ReduceByKeyFunction;
+import com.github.mdc.stream.functions.RightJoin;
 import com.github.mdc.stream.functions.RightOuterJoinPredicate;
 import com.github.mdc.stream.functions.SortedComparator;
 import com.github.mdc.stream.functions.TupleFlatMapFunction;
@@ -213,6 +216,111 @@ public sealed class MapPair<I1,I2> extends AbstractPipeline permits MapValues{
 			throw new PipelineException(PipelineConstants.INNERJOINCONDITION);
 		}
 		var mp = new MapPair(root, conditioninnerjoin);
+		this.childs.add(mp);
+		mp.parents.add(this);
+		mapright.childs.add(mp);
+		mp.parents.add(mapright);
+		root.mdsroots.add(mapright.root);
+		return mp;
+	}
+	
+
+	/**
+	 * MapPair constructor for Join
+	 * @param root
+	 * @param join
+	 */
+	protected MapPair(AbstractPipeline root,
+			Join join)  {
+		this.task = join;
+		this.root = root;
+		root.mdsroots.add(root);
+		root.finaltask=task;
+	}
+	
+	/**
+	 * MapPair accepts Join
+	 * @param <I3>
+	 * @param mapright
+	 * @return
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public <I3> MapPair<I1,Tuple2<I2,I3>> join(MapPair<I1,I3> mapright) throws PipelineException  {
+		if(Objects.isNull(mapright)) {
+			throw new PipelineException(PipelineConstants.INNERJOIN);
+		}
+		var mp = new MapPair(root, new Join());
+		this.childs.add(mp);
+		mp.parents.add(this);
+		mapright.childs.add(mp);
+		mp.parents.add(mapright);
+		root.mdsroots.add(mapright.root);
+		return mp;
+	}
+	
+	
+	/**
+	 * MapPair constructor for Left Join
+	 * @param root
+	 * @param join
+	 */
+	protected MapPair(AbstractPipeline root,
+			LeftJoin join)  {
+		this.task = join;
+		this.root = root;
+		root.mdsroots.add(root);
+		root.finaltask=task;
+	}
+	
+	/**
+	 * MapPair accepts Right Join
+	 * @param <I3>
+	 * @param mapright
+	 * @return
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public <I3> MapPair<I1,Tuple2<I2,I3>> leftJoin(MapPair<I1,I3> mapright) throws PipelineException  {
+		if(Objects.isNull(mapright)) {
+			throw new PipelineException(PipelineConstants.INNERJOIN);
+		}
+		var mp = new MapPair(root, new LeftJoin());
+		this.childs.add(mp);
+		mp.parents.add(this);
+		mapright.childs.add(mp);
+		mp.parents.add(mapright);
+		root.mdsroots.add(mapright.root);
+		return mp;
+	}
+	
+	
+	/**
+	 * MapPair constructor for Left Join
+	 * @param root
+	 * @param join
+	 */
+	protected MapPair(AbstractPipeline root,
+			RightJoin join)  {
+		this.task = join;
+		this.root = root;
+		root.mdsroots.add(root);
+		root.finaltask=task;
+	}
+	
+	/**
+	 * MapPair accepts Right Join
+	 * @param <I3>
+	 * @param mapright
+	 * @return
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public <I3> MapPair<I1,Tuple2<I2,I3>> rightJoin(MapPair<I1,I3> mapright) throws PipelineException  {
+		if(Objects.isNull(mapright)) {
+			throw new PipelineException(PipelineConstants.INNERJOIN);
+		}
+		var mp = new MapPair(root, new RightJoin());
 		this.childs.add(mp);
 		mp.parents.add(this);
 		mapright.childs.add(mp);

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/MapPairIgnite.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/MapPairIgnite.java
@@ -23,8 +23,10 @@ import com.github.mdc.stream.functions.FlatMapFunction;
 import com.github.mdc.stream.functions.FoldByKey;
 import com.github.mdc.stream.functions.GroupByKeyFunction;
 import com.github.mdc.stream.functions.IntersectionFunction;
+import com.github.mdc.stream.functions.Join;
 import com.github.mdc.stream.functions.JoinPredicate;
 import com.github.mdc.stream.functions.KeyByFunction;
+import com.github.mdc.stream.functions.LeftJoin;
 import com.github.mdc.stream.functions.LeftOuterJoinPredicate;
 import com.github.mdc.stream.functions.LongTupleFlatMapFunction;
 import com.github.mdc.stream.functions.MapToPairFunction;
@@ -32,6 +34,7 @@ import com.github.mdc.stream.functions.MapValuesFunction;
 import com.github.mdc.stream.functions.PeekConsumer;
 import com.github.mdc.stream.functions.PredicateSerializable;
 import com.github.mdc.stream.functions.ReduceByKeyFunction;
+import com.github.mdc.stream.functions.RightJoin;
 import com.github.mdc.stream.functions.RightOuterJoinPredicate;
 import com.github.mdc.stream.functions.SortedComparator;
 import com.github.mdc.stream.functions.TupleFlatMapFunction;
@@ -214,6 +217,110 @@ public sealed class MapPairIgnite<I1, I2> extends IgniteCommon permits MapValues
 			throw new PipelineException(PipelineConstants.INNERJOINCONDITION);
 		}
 		var mp = new MapPairIgnite(root, conditioninnerjoin);
+		this.childs.add(mp);
+		mp.parents.add(this);
+		mapright.childs.add(mp);
+		mp.parents.add(mapright);
+		root.mdsroots.add(mapright.root);
+		return mp;
+	}
+	
+	/**
+	 * MapPairIgnite constructor for Join
+	 * @param root
+	 * @param join
+	 */
+	protected MapPairIgnite(AbstractPipeline root,
+			Join join)  {
+		this.task = join;
+		this.root = root;
+		root.mdsroots.add(root);
+		root.finaltask=task;
+	}
+	
+	/**
+	 * MapPairIgnite accepts Join
+	 * @param <I3>
+	 * @param mapright
+	 * @return
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public <I3> MapPairIgnite<I1,Tuple2<I2,I3>> join(MapPairIgnite<I1,I3> mapright) throws PipelineException  {
+		if(Objects.isNull(mapright)) {
+			throw new PipelineException(PipelineConstants.INNERJOIN);
+		}
+		var mp = new MapPairIgnite(root, new Join());
+		this.childs.add(mp);
+		mp.parents.add(this);
+		mapright.childs.add(mp);
+		mp.parents.add(mapright);
+		root.mdsroots.add(mapright.root);
+		return mp;
+	}
+	
+	
+	/**
+	 * MapPairIgnite constructor for Left Join
+	 * @param root
+	 * @param join
+	 */
+	protected MapPairIgnite(AbstractPipeline root,
+			LeftJoin join)  {
+		this.task = join;
+		this.root = root;
+		root.mdsroots.add(root);
+		root.finaltask=task;
+	}
+	
+	/**
+	 * MapPairIgnite accepts Right Join
+	 * @param <I3>
+	 * @param mapright
+	 * @return
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public <I3> MapPairIgnite<I1,Tuple2<I2,I3>> leftJoin(MapPairIgnite<I1,I3> mapright) throws PipelineException  {
+		if(Objects.isNull(mapright)) {
+			throw new PipelineException(PipelineConstants.INNERJOIN);
+		}
+		var mp = new MapPairIgnite(root, new LeftJoin());
+		this.childs.add(mp);
+		mp.parents.add(this);
+		mapright.childs.add(mp);
+		mp.parents.add(mapright);
+		root.mdsroots.add(mapright.root);
+		return mp;
+	}
+	
+	
+	/**
+	 * MapPairIgnite constructor for Left Join
+	 * @param root
+	 * @param join
+	 */
+	protected MapPairIgnite(AbstractPipeline root,
+			RightJoin join)  {
+		this.task = join;
+		this.root = root;
+		root.mdsroots.add(root);
+		root.finaltask=task;
+	}
+	
+	/**
+	 * MapPairIgnite accepts Right Join
+	 * @param <I3>
+	 * @param mapright
+	 * @return
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public <I3> MapPairIgnite<I1,Tuple2<I2,I3>> rightJoin(MapPairIgnite<I1,I3> mapright) throws PipelineException  {
+		if(Objects.isNull(mapright)) {
+			throw new PipelineException(PipelineConstants.INNERJOIN);
+		}
+		var mp = new MapPairIgnite(root, new RightJoin());
 		this.childs.add(mp);
 		mp.parents.add(this);
 		mapright.childs.add(mp);

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/StreamPipeline.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/StreamPipeline.java
@@ -63,8 +63,10 @@ import com.github.mdc.stream.functions.FlatMapFunction;
 import com.github.mdc.stream.functions.FoldByKey;
 import com.github.mdc.stream.functions.GroupByKeyFunction;
 import com.github.mdc.stream.functions.IntersectionFunction;
+import com.github.mdc.stream.functions.Join;
 import com.github.mdc.stream.functions.JoinPredicate;
 import com.github.mdc.stream.functions.KeyByFunction;
+import com.github.mdc.stream.functions.LeftJoin;
 import com.github.mdc.stream.functions.LeftOuterJoinPredicate;
 import com.github.mdc.stream.functions.LongFlatMapFunction;
 import com.github.mdc.stream.functions.MapFunction;
@@ -72,6 +74,7 @@ import com.github.mdc.stream.functions.MapToPairFunction;
 import com.github.mdc.stream.functions.PeekConsumer;
 import com.github.mdc.stream.functions.PredicateSerializable;
 import com.github.mdc.stream.functions.ReduceFunction;
+import com.github.mdc.stream.functions.RightJoin;
 import com.github.mdc.stream.functions.RightOuterJoinPredicate;
 import com.github.mdc.stream.functions.SToIntFunction;
 import com.github.mdc.stream.functions.SortedComparator;
@@ -1011,6 +1014,9 @@ public sealed class StreamPipeline<I1> extends AbstractPipeline permits CsvStrea
 							|| af.task instanceof CountByKeyFunction
 							|| af.task instanceof CountByValueFunction
 							|| af.task instanceof JoinPredicate
+							|| af.task instanceof Join
+							|| af.task instanceof LeftJoin
+							|| af.task instanceof RightJoin
 							|| af.task instanceof LeftOuterJoinPredicate
 							|| af.task instanceof RightOuterJoinPredicate
 							|| af.task instanceof AggregateFunction
@@ -1035,7 +1041,10 @@ public sealed class StreamPipeline<I1> extends AbstractPipeline permits CsvStrea
 									|| af.parents.get(0).task instanceof SampleSupplierPartition
 									|| af.parents.get(0).task instanceof UnionFunction
 									|| af.parents.get(0).task instanceof FoldByKey
-									|| af.parents.get(0).task instanceof IntersectionFunction)) {
+									|| af.parents.get(0).task instanceof IntersectionFunction
+									|| af.parents.get(0).task instanceof Join
+									|| af.parents.get(0).task instanceof LeftJoin
+									|| af.parents.get(0).task instanceof RightJoin)) {
 						var parentstage = taskstagemap.get(af.parents.get(0).task);
 						parentstage.tasks.add(af.task);
 						taskstagemap.put(af.task, parentstage);

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/executors/StreamPipelineTaskExecutor.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/executors/StreamPipelineTaskExecutor.java
@@ -41,7 +41,6 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.apache.curator.shaded.com.google.common.collect.Iterables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -84,10 +83,13 @@ import com.github.mdc.stream.functions.CountByValueFunction;
 import com.github.mdc.stream.functions.FoldByKey;
 import com.github.mdc.stream.functions.GroupByKeyFunction;
 import com.github.mdc.stream.functions.IntersectionFunction;
+import com.github.mdc.stream.functions.Join;
 import com.github.mdc.stream.functions.JoinPredicate;
+import com.github.mdc.stream.functions.LeftJoin;
 import com.github.mdc.stream.functions.LeftOuterJoinPredicate;
 import com.github.mdc.stream.functions.Max;
 import com.github.mdc.stream.functions.Min;
+import com.github.mdc.stream.functions.RightJoin;
 import com.github.mdc.stream.functions.RightOuterJoinPredicate;
 import com.github.mdc.stream.functions.StandardDeviation;
 import com.github.mdc.stream.functions.Sum;
@@ -1254,6 +1256,97 @@ public sealed class StreamPipelineTaskExecutor implements
 				log.error(PipelineConstants.PROCESSRIGHTOUTERJOIN, ex);
 				throw new PipelineException(PipelineConstants.PROCESSRIGHTOUTERJOIN, ex);
 			}
+		} else if (jobstage.stage.tasks.get(0) instanceof Join jp) {
+			InputStream streamfirst = null;
+			InputStream streamsecond = null;
+			if ((task.input[0] instanceof BlocksLocation blfirst)
+					&& (task.input[1] instanceof BlocksLocation blsecond)) {
+				streamfirst = HdfsBlockReader.getBlockDataSnappyStream(blfirst, hdfs);
+				streamsecond = HdfsBlockReader.getBlockDataSnappyStream(blsecond, hdfs);
+			} else if (((task.input[0] instanceof BlocksLocation) && task.input[1] instanceof InputStream)
+					|| ((task.input[0] instanceof InputStream) && task.input[1] instanceof BlocksLocation)) {
+				streamfirst = task.input[0] instanceof BlocksLocation
+						? HdfsBlockReader.getBlockDataSnappyStream((BlocksLocation) task.input[0], hdfs)
+						: (InputStream) task.input[0];
+				streamsecond = task.input[1] instanceof BlocksLocation
+						? HdfsBlockReader.getBlockDataSnappyStream((BlocksLocation) task.input[1], hdfs)
+						: (InputStream) task.input[1];
+			} else {
+				streamfirst = (InputStream) task.input[0];
+				streamsecond = (InputStream) task.input[1];
+			}
+			try (var streamfirsttocompute = ((InputStream) streamfirst);
+					var streamsecondtocompute = ((InputStream) streamsecond);) {
+				timetakenseconds = processJoin(streamfirsttocompute, streamsecondtocompute,
+						task.input[0] instanceof BlocksLocation, task.input[1] instanceof BlocksLocation);
+			} catch (IOException ioe) {
+				log.error(PipelineConstants.FILEIOERROR, ioe);
+				throw new PipelineException(PipelineConstants.FILEIOERROR, ioe);
+			} catch (Exception ex) {
+				log.error(PipelineConstants.PROCESSJOIN, ex);
+				throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+			}
+
+		} else if (jobstage.stage.tasks.get(0) instanceof LeftJoin ljp) {
+			InputStream streamfirst = null;
+			InputStream streamsecond = null;
+			if ((task.input[0] instanceof BlocksLocation blfirst)
+					&& (task.input[1] instanceof BlocksLocation blsecond)) {
+				streamfirst = HdfsBlockReader.getBlockDataSnappyStream(blfirst, hdfs);
+				streamsecond = HdfsBlockReader.getBlockDataSnappyStream(blsecond, hdfs);
+			} else if (((task.input[0] instanceof BlocksLocation) && task.input[1] instanceof InputStream)
+					|| ((task.input[0] instanceof InputStream) && task.input[1] instanceof BlocksLocation)) {
+				streamfirst = task.input[0] instanceof BlocksLocation
+						? HdfsBlockReader.getBlockDataSnappyStream((BlocksLocation) task.input[0], hdfs)
+						: (InputStream) task.input[0];
+				streamsecond = task.input[1] instanceof BlocksLocation
+						? HdfsBlockReader.getBlockDataSnappyStream((BlocksLocation) task.input[1], hdfs)
+						: (InputStream) task.input[1];
+			} else {
+				streamfirst = (InputStream) task.input[0];
+				streamsecond = (InputStream) task.input[1];
+			}
+			try (var streamfirsttocompute = ((InputStream) streamfirst);
+					var streamsecondtocompute = ((InputStream) streamsecond);) {
+				timetakenseconds = processLeftJoin(streamfirsttocompute, streamsecondtocompute,
+						task.input[0] instanceof BlocksLocation, task.input[1] instanceof BlocksLocation);
+			} catch (IOException ioe) {
+				log.error(PipelineConstants.FILEIOERROR, ioe);
+				throw new PipelineException(PipelineConstants.FILEIOERROR, ioe);
+			} catch (Exception ex) {
+				log.error(PipelineConstants.PROCESSLEFTOUTERJOIN, ex);
+				throw new PipelineException(PipelineConstants.PROCESSLEFTOUTERJOIN, ex);
+			}
+		} else if (jobstage.stage.tasks.get(0) instanceof RightJoin rjp) {
+			InputStream streamfirst = null;
+			InputStream streamsecond = null;
+			if ((task.input[0] instanceof BlocksLocation blfirst)
+					&& (task.input[1] instanceof BlocksLocation blsecond)) {
+				streamfirst = HdfsBlockReader.getBlockDataSnappyStream(blfirst, hdfs);
+				streamsecond = HdfsBlockReader.getBlockDataSnappyStream(blsecond, hdfs);
+			} else if (((task.input[0] instanceof BlocksLocation) && task.input[1] instanceof InputStream)
+					|| ((task.input[0] instanceof InputStream) && task.input[1] instanceof BlocksLocation)) {
+				streamfirst = task.input[0] instanceof BlocksLocation
+						? HdfsBlockReader.getBlockDataSnappyStream((BlocksLocation) task.input[0], hdfs)
+						: (InputStream) task.input[0];
+				streamsecond = task.input[1] instanceof BlocksLocation
+						? HdfsBlockReader.getBlockDataSnappyStream((BlocksLocation) task.input[1], hdfs)
+						: (InputStream) task.input[1];
+			} else {
+				streamfirst = (InputStream) task.input[0];
+				streamsecond = (InputStream) task.input[1];
+			}
+			try (var streamfirsttocompute = ((InputStream) streamfirst);
+					var streamsecondtocompute = ((InputStream) streamsecond);) {
+				timetakenseconds = processRightJoin(streamfirsttocompute, streamsecondtocompute,
+						task.input[0] instanceof BlocksLocation, task.input[1] instanceof BlocksLocation);
+			} catch (IOException ioe) {
+				log.error(PipelineConstants.FILEIOERROR, ioe);
+				throw new PipelineException(PipelineConstants.FILEIOERROR, ioe);
+			} catch (Exception ex) {
+				log.error(PipelineConstants.PROCESSRIGHTOUTERJOIN, ex);
+				throw new PipelineException(PipelineConstants.PROCESSRIGHTOUTERJOIN, ex);
+			}
 		} else if (jobstage.stage.tasks.get(0) instanceof IntersectionFunction) {
 
 			if ((task.input[0] instanceof BlocksLocation blfirst)
@@ -1330,6 +1423,331 @@ public sealed class StreamPipelineTaskExecutor implements
 		return timetakenseconds;
 	}
 
+	/**
+	 * Join pair operation.
+	 * 
+	 * @param streamfirst
+	 * @param streamsecond
+	 * @param isinputfirstblocks
+	 * @param isinputsecondblocks
+	 * @return timetaken in milliseconds
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings("unchecked")
+	public double processJoin(InputStream streamfirst, InputStream streamsecond,
+			boolean isinputfirstblocks, boolean isinputsecondblocks) throws PipelineException {
+		log.debug("Entered MassiveDataStreamTaskDExecutor.processJoin");
+		var starttime = System.currentTimeMillis();
+
+		try (var fsdos = createIntermediateDataToFS(task);
+				var output = new Output(new SnappyOutputStream(new BufferedOutputStream(fsdos)));
+				var inputfirst = isinputfirstblocks ? null : new Input(streamfirst);
+				var inputsecond = isinputsecondblocks ? null : new Input(streamsecond);
+				var buffreader1 = isinputfirstblocks ? new BufferedReader(new InputStreamReader(streamfirst)) : null;
+				var buffreader2 = isinputsecondblocks ? new BufferedReader(new InputStreamReader(streamsecond)) : null;
+
+		) {
+
+			var kryo = Utils.getKryoNonDeflateSerializer();
+			final List<Tuple2> inputs1, inputs2;
+			;
+			if (Objects.isNull(buffreader1)) {
+				inputs1 = (List) kryo.readClassAndObject(inputfirst);
+			} else {
+				CompletableFuture<List> cf = buffreader1.lines().collect(ParallelCollectors.parallel(value -> value,
+						Collectors.toCollection(Vector::new), executor, Runtime.getRuntime().availableProcessors()));
+				inputs1 = cf.get();
+			}
+			if (Objects.isNull(buffreader2)) {
+				inputs2 = (List) kryo.readClassAndObject(inputsecond);
+			} else {
+				CompletableFuture<List> cf = buffreader2.lines().collect(ParallelCollectors.parallel(value -> value,
+						Collectors.toCollection(Vector::new), executor, Runtime.getRuntime().availableProcessors()));
+				inputs2 = cf.get();
+			}
+			var terminalCount = false;
+			if (jobstage.stage.tasks.get(0) instanceof CalculateCount) {
+				terminalCount = true;
+			}
+			
+			
+			Stream<Tuple2> joinpairs = inputs1.parallelStream().flatMap(tup1->{
+				return inputs2.parallelStream().filter(tup2->tup1.v1.equals(tup2.v1))
+				.map(tup2->new Tuple2(tup2.v1,new Tuple2(tup1.v2,tup2.v2))).collect(Collectors.toList()).stream();
+			});
+			
+			if (task.finalphase && task.saveresulttohdfs) {
+				try (OutputStream os = hdfs.create(new Path(task.hdfsurl + task.filepath),
+						Short.parseShort(MDCProperties.get().getProperty(MDCConstants.DFSOUTPUTFILEREPLICATION,
+								MDCConstants.DFSOUTPUTFILEREPLICATION_DEFAULT)));) {					
+					int ch = (int) '\n';
+					if (terminalCount) {
+						os.write(("" + joinpairs.count()).getBytes());
+					} else {
+						joinpairs.forEach(val -> {
+							try {
+								os.write(val.toString().getBytes());
+								os.write(ch);
+							} catch (IOException e) {
+							}
+						});
+					}
+				}
+				var timetaken = (System.currentTimeMillis() - starttime) / 1000.0;
+				return timetaken;
+			}
+			List joinpairsout;
+			if (terminalCount) {
+				joinpairsout = new Vector<>();
+				try {
+					joinpairsout.add(joinpairs.count());
+				} catch (Exception ex) {
+					log.error(PipelineConstants.PROCESSJOIN, ex);
+					throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+				}
+			} else {
+				joinpairsout=joinpairs.collect(Collectors.toList());
+
+			}
+			kryo.writeClassAndObject(output, joinpairsout);
+			output.flush();
+			cacheAble(fsdos);
+			var wr = new WeakReference<List>(joinpairsout);
+			joinpairsout = null;
+			log.debug("Exiting MassiveDataStreamTaskDExecutor.processJoin");
+			var timetaken = (System.currentTimeMillis() - starttime) / 1000.0;
+			log.debug("Time taken to compute the Join task is " + timetaken + " seconds");
+			log.debug("GC Status Join task:" + Utils.getGCStats());
+			return timetaken;
+		} catch (IOException ioe) {
+			log.error(PipelineConstants.FILEIOERROR, ioe);
+			throw new PipelineException(PipelineConstants.FILEIOERROR, ioe);
+		} catch (Exception ex) {
+			log.error(PipelineConstants.PROCESSJOIN, ex);
+			throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+		}
+	}
+	
+	
+	/**
+	 * Left Join pair operation.
+	 * 
+	 * @param streamfirst
+	 * @param streamsecond
+	 * @param isinputfirstblocks
+	 * @param isinputsecondblocks
+	 * @return timetaken in milliseconds
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings("unchecked")
+	public double processLeftJoin(InputStream streamfirst, InputStream streamsecond,
+			boolean isinputfirstblocks, boolean isinputsecondblocks) throws PipelineException {
+		log.debug("Entered MassiveDataStreamTaskDExecutor.processLeftJoin");
+		var starttime = System.currentTimeMillis();
+
+		try (var fsdos = createIntermediateDataToFS(task);
+				var output = new Output(new SnappyOutputStream(new BufferedOutputStream(fsdos)));
+				var inputfirst = isinputfirstblocks ? null : new Input(streamfirst);
+				var inputsecond = isinputsecondblocks ? null : new Input(streamsecond);
+				var buffreader1 = isinputfirstblocks ? new BufferedReader(new InputStreamReader(streamfirst)) : null;
+				var buffreader2 = isinputsecondblocks ? new BufferedReader(new InputStreamReader(streamsecond)) : null;
+
+		) {
+
+			var kryo = Utils.getKryoNonDeflateSerializer();
+			final List<Tuple2> inputs1, inputs2;
+			;
+			if (Objects.isNull(buffreader1)) {
+				inputs1 = (List) kryo.readClassAndObject(inputfirst);
+			} else {
+				CompletableFuture<List> cf = buffreader1.lines().collect(ParallelCollectors.parallel(value -> value,
+						Collectors.toCollection(Vector::new), executor, Runtime.getRuntime().availableProcessors()));
+				inputs1 = cf.get();
+			}
+			if (Objects.isNull(buffreader2)) {
+				inputs2 = (List) kryo.readClassAndObject(inputsecond);
+			} else {
+				CompletableFuture<List> cf = buffreader2.lines().collect(ParallelCollectors.parallel(value -> value,
+						Collectors.toCollection(Vector::new), executor, Runtime.getRuntime().availableProcessors()));
+				inputs2 = cf.get();
+			}
+			var terminalCount = false;
+			if (jobstage.stage.tasks.get(0) instanceof CalculateCount) {
+				terminalCount = true;
+			}
+			
+			
+			Stream<Tuple2> joinpairs = inputs1.parallelStream().flatMap(tup1->{
+				List<Tuple2> joinlist = inputs2.parallelStream().filter(tup2->tup1.v1.equals(tup2.v1))
+				.map(tup2->new Tuple2(tup2.v1,new Tuple2(tup1.v2,tup2.v2))).collect(Collectors.toList());
+				if(joinlist.isEmpty()) {
+					return Arrays.asList(new Tuple2(tup1.v1,new Tuple2(tup1.v2,null))).stream();
+				}				
+				return joinlist.stream();
+			});
+			
+			if (task.finalphase && task.saveresulttohdfs) {
+				try (OutputStream os = hdfs.create(new Path(task.hdfsurl + task.filepath),
+						Short.parseShort(MDCProperties.get().getProperty(MDCConstants.DFSOUTPUTFILEREPLICATION,
+								MDCConstants.DFSOUTPUTFILEREPLICATION_DEFAULT)));) {					
+					int ch = (int) '\n';
+					if (terminalCount) {
+						os.write(("" + joinpairs.count()).getBytes());
+					} else {
+						joinpairs.forEach(val -> {
+							try {
+								os.write(val.toString().getBytes());
+								os.write(ch);
+							} catch (IOException e) {
+							}
+						});
+					}
+				}
+				var timetaken = (System.currentTimeMillis() - starttime) / 1000.0;
+				return timetaken;
+			}
+			List joinpairsout;
+			if (terminalCount) {
+				joinpairsout = new Vector<>();
+				try {
+					joinpairsout.add(joinpairs.count());
+				} catch (Exception ex) {
+					log.error(PipelineConstants.PROCESSJOIN, ex);
+					throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+				}
+			} else {
+				joinpairsout=joinpairs.collect(Collectors.toList());
+
+			}
+			kryo.writeClassAndObject(output, joinpairsout);
+			output.flush();
+			cacheAble(fsdos);
+			var wr = new WeakReference<List>(joinpairsout);
+			joinpairsout = null;
+			log.debug("Exiting MassiveDataStreamTaskDExecutor.processLeftJoin");
+			var timetaken = (System.currentTimeMillis() - starttime) / 1000.0;
+			log.debug("Time taken to compute the Join task is " + timetaken + " seconds");
+			log.debug("GC Status Join task:" + Utils.getGCStats());
+			return timetaken;
+		} catch (IOException ioe) {
+			log.error(PipelineConstants.FILEIOERROR, ioe);
+			throw new PipelineException(PipelineConstants.FILEIOERROR, ioe);
+		} catch (Exception ex) {
+			log.error(PipelineConstants.PROCESSJOIN, ex);
+			throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+		}
+	}
+	
+	/**
+	 * Left Join pair operation.
+	 * 
+	 * @param streamfirst
+	 * @param streamsecond
+	 * @param isinputfirstblocks
+	 * @param isinputsecondblocks
+	 * @return timetaken in milliseconds
+	 * @throws PipelineException
+	 */
+	@SuppressWarnings("unchecked")
+	public double processRightJoin(InputStream streamfirst, InputStream streamsecond,
+			boolean isinputfirstblocks, boolean isinputsecondblocks) throws PipelineException {
+		log.debug("Entered MassiveDataStreamTaskDExecutor.processRightJoin");
+		var starttime = System.currentTimeMillis();
+
+		try (var fsdos = createIntermediateDataToFS(task);
+				var output = new Output(new SnappyOutputStream(new BufferedOutputStream(fsdos)));
+				var inputfirst = isinputfirstblocks ? null : new Input(streamfirst);
+				var inputsecond = isinputsecondblocks ? null : new Input(streamsecond);
+				var buffreader1 = isinputfirstblocks ? new BufferedReader(new InputStreamReader(streamfirst)) : null;
+				var buffreader2 = isinputsecondblocks ? new BufferedReader(new InputStreamReader(streamsecond)) : null;
+
+		) {
+
+			var kryo = Utils.getKryoNonDeflateSerializer();
+			final List<Tuple2> inputs1, inputs2;
+			;
+			if (Objects.isNull(buffreader1)) {
+				inputs1 = (List) kryo.readClassAndObject(inputfirst);
+			} else {
+				CompletableFuture<List> cf = buffreader1.lines().collect(ParallelCollectors.parallel(value -> value,
+						Collectors.toCollection(Vector::new), executor, Runtime.getRuntime().availableProcessors()));
+				inputs1 = cf.get();
+			}
+			if (Objects.isNull(buffreader2)) {
+				inputs2 = (List) kryo.readClassAndObject(inputsecond);
+			} else {
+				CompletableFuture<List> cf = buffreader2.lines().collect(ParallelCollectors.parallel(value -> value,
+						Collectors.toCollection(Vector::new), executor, Runtime.getRuntime().availableProcessors()));
+				inputs2 = cf.get();
+			}
+			var terminalCount = false;
+			if (jobstage.stage.tasks.get(0) instanceof CalculateCount) {
+				terminalCount = true;
+			}
+			
+			
+			Stream<Tuple2> joinpairs = inputs2.parallelStream().flatMap(tup1->{
+				List<Tuple2> joinlist = inputs1.parallelStream().filter(tup2->tup1.v1.equals(tup2.v1))
+				.map(tup2->new Tuple2(tup2.v1,new Tuple2(tup2.v2,tup1.v2))).collect(Collectors.toList());
+				if(joinlist.isEmpty()) {
+					return Arrays.asList(new Tuple2(tup1.v1,new Tuple2(null,tup1.v2))).stream();
+				}				
+				return joinlist.stream();
+			});
+			
+			if (task.finalphase && task.saveresulttohdfs) {
+				try (OutputStream os = hdfs.create(new Path(task.hdfsurl + task.filepath),
+						Short.parseShort(MDCProperties.get().getProperty(MDCConstants.DFSOUTPUTFILEREPLICATION,
+								MDCConstants.DFSOUTPUTFILEREPLICATION_DEFAULT)));) {					
+					int ch = (int) '\n';
+					if (terminalCount) {
+						os.write(("" + joinpairs.count()).getBytes());
+					} else {
+						joinpairs.forEach(val -> {
+							try {
+								os.write(val.toString().getBytes());
+								os.write(ch);
+							} catch (IOException e) {
+							}
+						});
+					}
+				}
+				var timetaken = (System.currentTimeMillis() - starttime) / 1000.0;
+				return timetaken;
+			}
+			List joinpairsout;
+			if (terminalCount) {
+				joinpairsout = new Vector<>();
+				try {
+					joinpairsout.add(joinpairs.count());
+				} catch (Exception ex) {
+					log.error(PipelineConstants.PROCESSJOIN, ex);
+					throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+				}
+			} else {
+				joinpairsout=joinpairs.collect(Collectors.toList());
+
+			}
+			kryo.writeClassAndObject(output, joinpairsout);
+			output.flush();
+			cacheAble(fsdos);
+			var wr = new WeakReference<List>(joinpairsout);
+			joinpairsout = null;
+			log.debug("Exiting MassiveDataStreamTaskDExecutor.processRightJoin");
+			var timetaken = (System.currentTimeMillis() - starttime) / 1000.0;
+			log.debug("Time taken to compute the Join task is " + timetaken + " seconds");
+			log.debug("GC Status Join task:" + Utils.getGCStats());
+			return timetaken;
+		} catch (IOException ioe) {
+			log.error(PipelineConstants.FILEIOERROR, ioe);
+			throw new PipelineException(PipelineConstants.FILEIOERROR, ioe);
+		} catch (Exception ex) {
+			log.error(PipelineConstants.PROCESSJOIN, ex);
+			throw new PipelineException(PipelineConstants.PROCESSJOIN, ex);
+		}
+	}
+	
+	
 	/**
 	 * Join pair operation.
 	 * 

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/functions/Join.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/functions/Join.java
@@ -1,0 +1,9 @@
+package com.github.mdc.stream.functions;
+
+import java.io.Serializable;;
+
+public class Join implements Serializable{
+
+	private static final long serialVersionUID = 6211485298329706929L;
+
+}

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/functions/LeftJoin.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/functions/LeftJoin.java
@@ -1,0 +1,9 @@
+package com.github.mdc.stream.functions;
+
+import java.io.Serializable;
+
+public class LeftJoin implements Serializable{
+
+	private static final long serialVersionUID = 2531701490681918300L;
+
+}

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/functions/RightJoin.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/functions/RightJoin.java
@@ -1,0 +1,9 @@
+package com.github.mdc.stream.functions;
+
+import java.io.Serializable;
+
+public class RightJoin implements Serializable{
+
+	private static final long serialVersionUID = 902007710735029947L;
+
+}

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/scheduler/StreamJobScheduler.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/scheduler/StreamJobScheduler.java
@@ -1699,9 +1699,10 @@ public class StreamJobScheduler {
 						rdf.jobid = task.jobid;
 						rdf.stageid = task.stageid;
 						rdf.taskid = task.taskid;
-						rdf.mode = Boolean.parseBoolean(pipelineconfig.getJgroups())?MDCConstants.JGROUPS:MDCConstants.STANDALONE;
+						boolean isJGroups = Boolean.parseBoolean(pipelineconfig.getJgroups());
+						rdf.mode = isJGroups?MDCConstants.JGROUPS:MDCConstants.STANDALONE;
 						RemoteDataFetcher.remoteInMemoryDataFetch(rdf);
-						try (var input = new Input(new SnappyInputStream(new ByteArrayInputStream(rdf.data)));) {
+						try (var input = new Input(!isJGroups?new SnappyInputStream(new ByteArrayInputStream(rdf.data)):new ByteArrayInputStream(rdf.data));) {
 							var obj = kryofinal.readClassAndObject(input);
 							writeOutputToFile(stageoutput.size(),obj);
 							stageoutput.add(obj);

--- a/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/scheduler/StreamJobScheduler.java
+++ b/massivedatacruncher/pipeline/src/main/java/com/github/mdc/stream/scheduler/StreamJobScheduler.java
@@ -103,8 +103,11 @@ import com.github.mdc.stream.executors.StreamPipelineTaskExecutorIgnite;
 import com.github.mdc.stream.functions.AggregateReduceFunction;
 import com.github.mdc.stream.functions.Coalesce;
 import com.github.mdc.stream.functions.IntersectionFunction;
+import com.github.mdc.stream.functions.Join;
 import com.github.mdc.stream.functions.JoinPredicate;
+import com.github.mdc.stream.functions.LeftJoin;
 import com.github.mdc.stream.functions.LeftOuterJoinPredicate;
+import com.github.mdc.stream.functions.RightJoin;
 import com.github.mdc.stream.functions.RightOuterJoinPredicate;
 import com.github.mdc.stream.functions.UnionFunction;
 import com.github.mdc.stream.mesos.scheduler.MesosScheduler;
@@ -1477,7 +1480,10 @@ public class StreamJobScheduler {
 			}
 			// Form the edges and nodes for the JoinPair function.
 			else if (function instanceof JoinPredicate || function instanceof LeftOuterJoinPredicate
-					|| function instanceof RightOuterJoinPredicate) {
+					|| function instanceof RightOuterJoinPredicate
+					|| function instanceof Join 
+					|| function instanceof LeftJoin
+					|| function instanceof RightJoin) {
 				for (var inputparent1 : outputparent1) {
 					for (var inputparent2 : outputparent2) {
 						partitionindex++;

--- a/massivedatacruncher/pom.xml
+++ b/massivedatacruncher/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>15</maven.compiler.target>
         <maven.compiler.source>15</maven.compiler.source>
         <skip.assemblyxml>true</skip.assemblyxml>
-        <ignite.version>2.11.1</ignite.version>
+        <ignite.version>2.13.0</ignite.version>
         <calcite.version>1.25.0</calcite.version>
     </properties>
 
@@ -288,7 +288,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.8.1</version>
+            <version>1.1.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Test cases failure fixes.
Jgroups Bind Address (jgroups.bind_addr) Configuration.
Join, left join and right join for the mappair and mappair ignite.